### PR TITLE
Push index image to test registry

### DIFF
--- a/.github/workflows/test-index-image.yml
+++ b/.github/workflows/test-index-image.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set test bundle image
         run: echo "TEST_BUNDLE_IMAGE=${{ env.BUNDLE_IMAGE_NAME }}:${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
       - name: Set index image name
-        run: echo "INDEX_IMAGE=storageos/operator-index:test" >> $GITHUB_ENV
+        run: echo "INDEX_IMAGE=ghcr.io/storageos/operator-index:${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
       - uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -44,6 +44,7 @@ jobs:
       - name: Build catalog index image
         run: |
           make index-build INDEX_BUNDLES=${{ env.TEST_BUNDLE_IMAGE }} INDEX_IMAGE=${{ env.INDEX_IMAGE }}
+          docker push ${{ env.INDEX_IMAGE }}
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.0.0
         with:
@@ -67,6 +68,8 @@ jobs:
           sudo mv kubectl-operator /usr/local/bin/
       - name: Install catalog
         run: |
+          make yq
+          ./bin/yq w -i examples/catalogsource.yaml spec.image ${{ env.INDEX_IMAGE }}
           kubectl apply -f examples/catalogsource.yaml
           until kubectl get pods | grep storageos-catalog | grep -q Running; do sleep 5; done
           kubectl operator catalog list -A

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ OPM_VERSION=v1.14.2
 CONFTEST=bin/conftest
 CONFTEST_VERSION=v0.21.0
 
+YQ=bin/yq
+YQ_VERSION=3.4.0
+
 ARCH=amd64
 
 PROJECT_DIR=$(shell pwd)
@@ -128,4 +131,11 @@ conftest: ## Install conftest
 		curl -Lo conftest.tar.gz https://github.com/open-policy-agent/conftest/releases/download/${CONFTEST_VERSION}/conftest_0.21.0_Linux_x86_64.tar.gz; \
 		tar zxvf conftest.tar.gz; \
 		cp conftest $(PROJECT_DIR)/$(CONFTEST); \
+	fi
+
+yq: ## Install yq.
+	mkdir -p bin
+	@if [ ! -f $(YQ) ]; then \
+		curl -Lo $(YQ) https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${ARCH} ;\
+		chmod +x $(YQ) ;\
 	fi


### PR DESCRIPTION
New OLM release caused the e2e test failure.
OLM v0.17.0 changes the image pull policy to always for non-digest
images. images must be pushed to a remote repo to have a repo-digest.
The bundle is loaded in the kind node and used. Due to the OLM changes,
the loaded image is no longer used.
Like the bundle image, push the index image to github container registry
and use in OLM e2e test.

Also, installs yq and uses it to update the catalog source image.