### PR TITLE
Upadte peter-evans/create-pull-request to v3.8.0

### DIFF
--- a/.github/workflows/generate-bundle.yml
+++ b/.github/workflows/generate-bundle.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Tree output
         run: echo "${{ steps.olm.outputs.tree }}"
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3.4.0
+        uses: peter-evans/create-pull-request@v3.8.0
         id: cpr
         with:
           commit-message: "Update bundle ${{ env.OUTPUT_DIR }}"


### PR DESCRIPTION
Uses new Github action configuration in the latest action version.
Some attributes in the old configurations used by create-pull-request
action have been deprecated.