### PR TITLE
node:v2.4.0 tag broken

### DIFF
--- a/storageos2/2.4.0/manifests/storageosoperator.clusterserviceversion.yaml
+++ b/storageos2/2.4.0/manifests/storageosoperator.clusterserviceversion.yaml
@@ -491,7 +491,7 @@ spec:
                       - name: OPERATOR_NAME
                         value: storageos-cluster-operator
                       - name: RELATED_IMAGE_STORAGEOS_NODE
-                        value: registry.connect.redhat.com/storageos/node:v2.4.0
+                        value: registry.connect.redhat.com/storageos/node:v2.4.0-1
                       - name: RELATED_IMAGE_STORAGEOS_INIT
                         value: registry.connect.redhat.com/storageos/init:v2.1.0-1
                       - name: RELATED_IMAGE_API_MANAGER

--- a/storageos2/imagelist-2.4.0.yaml
+++ b/storageos2/imagelist-2.4.0.yaml
@@ -1,5 +1,5 @@
 - name: RELATED_IMAGE_STORAGEOS_NODE
-  value: registry.connect.redhat.com/storageos/node:v2.4.0
+  value: registry.connect.redhat.com/storageos/node:v2.4.0-1
 - name: RELATED_IMAGE_STORAGEOS_INIT
   value: registry.connect.redhat.com/storageos/init:v2.1.0-1
 - name: RELATED_IMAGE_API_MANAGER


### PR DESCRIPTION
Red Hat registry is not allowing us to use the `v2.4.0` tag as it believes it is already used (but it's not).  Use `v2.4.0-1` instead which does exist.